### PR TITLE
docs: agregar archivo .gitignore para excluir la carpeta de archivos auxiliares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Carpeta de archivos auxiliares
+.dev_aux/


### PR DESCRIPTION
Agrega la carpeta .dev_aux/ al .gitignore